### PR TITLE
make directive able to be minified

### DIFF
--- a/app/js/directives.js
+++ b/app/js/directives.js
@@ -3,7 +3,7 @@
 angular.module('app.directives', [])
 
     // Main directive, that just publish a controller
-    .directive('frangTree', function ($parse, $animate) {
+    .directive('frangTree', ['$parse', '$animate', function ($parse, $animate) {
         return {
             restrict: 'EA',
             controller: function($scope, $element) {
@@ -13,9 +13,9 @@ angular.module('app.directives', [])
                 };
             }
         };
-    })
+    }])
 
-    .directive('frangTreeRepeat', function ($parse, $animate) {
+    .directive('frangTreeRepeat', ['$parse', '$animate', function ($parse, $animate) {
 
         // ---------- Some necessary internal functions from angular.js ----------
 
@@ -367,7 +367,7 @@ angular.module('app.directives', [])
 
             }
         };
-    })
+    }])
 
     .directive('frangTreeInsertChildren', function () {
         return {
@@ -382,7 +382,7 @@ angular.module('app.directives', [])
         };
     })
 
-    .directive('frangTreeDrag', function($parse) {
+    .directive('frangTreeDrag', ['$parse', function($parse) {
         return {
             restrict: 'A',
             require: '^frangTree',
@@ -414,9 +414,9 @@ angular.module('app.directives', [])
                 );
             }
         };
-    })
+    }])
 
-    .directive('frangTreeDrop', function($parse) {
+    .directive('frangTreeDrop', ['$parse', function($parse) {
         return {
             restrict: 'A',
             require: '^frangTree',
@@ -480,5 +480,4 @@ angular.module('app.directives', [])
                 );
             }
         }
-    });
-
+    }]);


### PR DESCRIPTION
Angular,  by default, infers the dependencies based on their names, but this behavior breaks when the directive is minified.

In order to be able to minify the directive, I had to annotate the functions with the names of the depedencies, the same way that the angular docs suggests to do in controller definitions. (See, [note on minification](https://docs.angularjs.org/tutorial/step_05))
